### PR TITLE
Add remove option.

### DIFF
--- a/src/Droppler.vue
+++ b/src/Droppler.vue
@@ -24,8 +24,8 @@ export default {
         'hoverCloseDelay',
         'focusDelay',
         'blurDelay',
-        'tetherOptions'
-
+        'tetherOptions',
+        'remove'
     ],
 
     data() {
@@ -48,7 +48,8 @@ export default {
             hoverCloseDelay: this.hoverOpenDelay ? this.hoverCloseDelay : 50,
             focusDelay: this.focusDelay ? this.focusDelay : 0,
             blurDelay: this.blurDelay ? this.blurDelay : 50,
-            tetherOptions: this.tetherOptions ? this.tetherOptions : {}
+            tetherOptions: this.tetherOptions ? this.tetherOptions : {},
+            remove: this.remove ? true : false,
         });
     }
 }


### PR DESCRIPTION
According to the drop docs, "Set to true if you'd like the drop element
to be removed from the DOM when the drop is closed and recreated when
it's opened.

I found this was the only way it worked in our vue app.